### PR TITLE
Scrape waterfall database

### DIFF
--- a/waterfalls/_targets.R
+++ b/waterfalls/_targets.R
@@ -2,9 +2,15 @@
 library(targets)
 
 options(tidyverse.quiet = TRUE)
-tar_option_set(packages = c('tidyverse', 'sbtools', 'geojsonR', 'sp','sf', 'waterfall', 'ggthemes', 'readr'))
+tar_option_set(packages = c('tidyverse', 'sbtools', 'geojsonR', 'sp','sf', 
+                            'waterfall', 'ggthemes', 'readr','rvest', 'xml2'),
+               error = NULL)
 
 source("src/functions.R")
+source('src/scrape_waterfall_data.R')
+
+## waterfall database site
+url <- 'https://www.worldwaterfalldatabase.com/country/United-States/list'
 
 ## Global options
 
@@ -18,10 +24,97 @@ list(
                  destinations = "out/conterminousUS_falls_nhd.geojson"),
     format = "file"
   ),
-  # Read in web-scraped data (optional, if not using Cee's code)
+  
+  # Scraping the waterfall database
   tar_target(
-    wwdb_scraped_df,
-    read_data_wwdb(file = "in/us_waterfalls.csv")
+    # get urls for all database pages to scrape
+    ## taking the second last list item (li) of the page navigation below the table
+    ## where the integer represents total number of pages in the database
+    n_pages,
+    url %>%
+      read_html() %>%
+      html_element('ul.pagination') %>%
+      html_elements('li') %>%
+      tail(2) %>%
+      head(1) %>%
+      html_text() %>%
+      as.integer()
+  ),
+  ## extract table header and reformat
+  tar_target(
+    table_header,
+    c('Status', 'Waterfall','Access','Country Rating','Height','State')
+  ),
+  ## create a tibble of every url to scrape
+  tar_target(
+    page_df,
+    tibble(page_num = 1:n_pages,
+           page_url = sprintf('https://www.worldwaterfalldatabase.com/country/United-States/list?page=%s', page_num))
+  ),
+  # for each page of the database, scrape table data
+  ## fall_type corresponds to html classes for each row that indicate whether the entry is confirmed, cataloged etc
+  ## doing this for confirmed and cataloged entries, separately
+  ## create a branch for every "page" in the database
+  tar_target(
+    ## pull data into a table, takes around 10 min
+    confirmed_df,
+    extract_tbl_contents(url = page_df$page_url,
+                         fall_type = '.Confirmed-row',
+                         table_head = table_header),
+    pattern = map(page_df)
+  ),
+  tar_target(
+    cataloged_df,
+    extract_tbl_contents(url = page_df$page_url,
+                         fall_type = '.Cataloged-row',
+                         table_head = table_header),
+    pattern = map(page_df)
+  ),
+  # now take the urls for each waterfall entry that lead to more info
+  tar_target(
+    confirmed_urls,
+    confirmed_df %>% ungroup() %>% pull(url) %>% unique()
+  ),
+  tar_target(
+    cataloged_urls,
+    cataloged_df %>% ungroup() %>% pull(url) %>% unique()
+  ),
+  # and use to scrape additional stats from those pages (this takes a while)
+  ## create a branch for every waterfall entry
+  ## a few sites error out, so using tryCatch to work through
+  tar_target(
+    ## this step takes a while ~30 min
+    cataloged_stats,
+    tryCatch(
+      add_fall_info(cataloged_urls),
+      error = function(e){message(cataloged_urls)}
+    ),
+    pattern = map(cataloged_urls)
+  ),
+  tar_target(
+    ## this step takes a while ~30 min
+    confirmed_stats,
+    tryCatch(
+      add_fall_info(confirmed_urls),
+      error = function(e){message(confirmed_urls)}
+    ),
+    pattern = map(confirmed_urls)
+  ),
+  tar_target(
+    ## combine data
+    wf_df,
+    bind_rows(confirmed_df %>% left_join(confirmed_stats),
+              cataloged_df %>% left_join(cataloged_stats)) 
+  ),
+  tar_target(
+    # save
+    waterfall_df_csv,
+    {
+      out_file <- 'out/us_waterfalls.csv'
+      write_csv(wf_df, out_file)
+      return(out_file)
+    },
+    format = 'file'
   )
 )
 

--- a/waterfalls/src/scrape_waterfall_data.R
+++ b/waterfalls/src/scrape_waterfall_data.R
@@ -1,0 +1,64 @@
+extract_tbl_contents <- function(url, fall_type = '.Confirmed-row', table_head){
+  
+  ## locate data table
+  fall_rows <- url %>%
+    read_html() %>%
+    # locate the table
+    html_element('div .tableWrapper') %>% 
+    # select rows by fall type
+    html_elements(fall_type) 
+  
+  ## table isn't written as a standard html table so need to 
+  ## work to pull out the desired content from cells
+  fall_data <- fall_rows %>%
+    # extract row cells
+    html_elements('.tableCell') %>%
+    # convert to text
+    html_text2()%>%
+    # clean text
+    str_replace_all("[\r\n]" , "") %>%
+    str_squish()
+  
+  ## also pull the link for the fall-specific page
+  fall_a <- fall_rows %>%
+    # extract row cells
+    html_element('.tableCell.sortColumn') %>%
+    html_element('a') %>%
+    html_attr('href')
+  fall_links <- fall_a[-1]
+  
+  # populate data frame
+  # fall_data returns a list of values
+  wf_df <- tibble(
+    var = rep(table_head, length(fall_data)/length(table_head)),
+    val = fall_data) %>%
+    # create a grouping var that represents each row
+    mutate(fall_id = floor((row_number()-0.1)/length(table_head))) %>%
+    # convert to wide to match site format
+    pivot_wider(names_from = 'var', values_from = 'val') %>%
+    mutate(Status = fall_type) %>%
+    mutate(url = fall_links)
+
+  return(wf_df)
+  
+
+}
+
+add_fall_info <- function(url){
+
+   page_tables <- url %>%
+    read_html() %>%
+    html_table() 
+   
+   ratings <- page_tables[[1]]
+   geo_data <- page_tables[[2]]
+   stats <- page_tables[[3]]
+   
+  ratings %>%
+    bind_rows(geo_data) %>%
+    rename(name = X1, value = X2) %>%
+    bind_rows(stats %>% select(name = X1, value = X3)) %>%
+    pivot_wider() %>%
+    mutate(url = url)
+
+}


### PR DESCRIPTION
This scrapes data for U.S. waterfalls listed in the waterfall database at https://www.worldwaterfalldatabase.com/country/United-States/list The final output includes a wide dataframe with entries that are 'confirmed' or 'catalogued'. The steps are as follows:
1. Identify the total number of pages int he paginated web version of the database
2. Use the number of pages to construct a list of urls to scrape corresponding to each page of the website.
3. Scrape the table from each page using dynamic branching over the list of urls. In this step, html classes corresponding to the status of each waterfall entry are used to select which rows to scrape, i.e. `Confirmed-row` scrapes confirmed waterfalls and `Cataloged-row` are cataloged. There are other levels that were not included. Scraped data include urls for waterfall-specific pages with more info.
4.  Use the list of waterfall-specific urls to scrape more detailed info about each waterfall. These data are minimally processed and will need some more wrangling to use. I selected for only metric measurements but that could be changed by modifying `add_fall_info`. The line `bind_rows(stats %>% select(name = X1, value = X3)) %>%` should be replaced with `bind_rows(stats %>% select(name = X1, value = X2)) %>%` to do so.
5. 5. Combine everything and export.
The whole thing takes a while to run do to the many page requests, I'd guess around 2 hours.
